### PR TITLE
Fixes missing RF_CHANNEL define at contiki-z1-main

### DIFF
--- a/examples/ipv6/slip-radio/project-conf.h
+++ b/examples/ipv6/slip-radio/project-conf.h
@@ -44,6 +44,10 @@
 
 #define CMD_CONF_OUTPUT slip_radio_cmd_output
 
+#ifndef RF_CHANNEL
+#define RF_CHANNEL 26
+#endif
+
 #if RADIO_DEVICE_cc2420
 #define CMD_CONF_HANDLERS slip_radio_cmd_handler,cmd_handler_cc2420
 #elif CONTIKI_TARGET_SKY


### PR DESCRIPTION
When compiling the slip-radio for the Z1 target, it fails as the RF_CHANNEL define is missing.
