### PR TITLE
fix buffer overflow in uip_buf, reserve space for LLH

### DIFF
--- a/examples/6lbr/project-conf.h
+++ b/examples/6lbr/project-conf.h
@@ -81,9 +81,6 @@
 #undef RPL_CONF_INIT_LINK_METRIC
 #define RPL_CONF_INIT_LINK_METRIC			2
 
-#undef UIP_CONF_BUFFER_SIZE
-#define UIP_CONF_BUFFER_SIZE				1280
-
 // Avoid 6lowpan fragmentation
 #define REST_MAX_CHUNK_SIZE                 64
 
@@ -99,6 +96,9 @@
 // Ethernet header is stored in uip_buf
 #undef UIP_CONF_LLH_LEN
 #define UIP_CONF_LLH_LEN 14
+
+#undef UIP_CONF_BUFFER_SIZE
+#define UIP_CONF_BUFFER_SIZE				1280 + UIP_CONF_LLH_LEN
 
 // Include Global addresses in mDNS
 #define RESOLV_CONF_MDNS_INCLUDE_GLOBAL_V6_ADDRS 1


### PR DESCRIPTION
In uipopt.h UIP_BUFSIZE is set to 1280 + UIP_LLH_LEN by default, but the
UIP_CONF_BUFFER_SIZE in 6lbr project.conf was overriding it to only 1280.

I experienced crashes in smart_bridge mode when receiving packets of 1280 bytes on the Ethernet side. This fixed it.