### PR TITLE
added more endianness detection

### DIFF
--- a/examples/6lbr/platform/native/6lbr-conf-native.h
+++ b/examples/6lbr/platform/native/6lbr-conf-native.h
@@ -101,6 +101,7 @@
 #define NETSTACK_CONF_RADIO   nullradio_driver
 
 #if defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN || \
+    defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__ || \
     defined(__BIG_ENDIAN__) || \
     defined(__ARMEB__) || \
     defined(__THUMBEB__) || \
@@ -109,6 +110,7 @@
 #undef UIP_CONF_BYTE_ORDER
 #define UIP_CONF_BYTE_ORDER UIP_BIG_ENDIAN
 #elif defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN || \
+    defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __LITTLE_ENDIAN__ || \
     defined(__LITTLE_ENDIAN__) || \
     defined(__ARMEL__) || \
     defined(__THUMBEL__) || \


### PR DESCRIPTION
this fixes compilation for MIPS 24k with gcc-5.3.0  (tested with gcc-5.3.0 and musl on openwrt trunk)

I can verify that the default endianness macros in gcc are the following:

`$ mips-openwrt-linux-musl-gcc -dM -E - < /dev/null | grep ENDIAN`
`#define __ORDER_LITTLE_ENDIAN__ 1234`
`#define __FLOAT_WORD_ORDER__ __ORDER_BIG_ENDIAN__`
`#define __ORDER_PDP_ENDIAN__ 3412`
`#define __ORDER_BIG_ENDIAN__ 4321`
`#define __BYTE_ORDER__ __ORDER_BIG_ENDIAN__`

I can verify this for gcc 5.2, 5.3 and 6.1 for any arch
 