### PR TITLE
Fix issue that doesn't allow dio_redundancy == 0 to disable dio suppression

### DIFF
--- a/core/net/rpl/rpl-timers.c
+++ b/core/net/rpl/rpl-timers.c
@@ -155,7 +155,7 @@ handle_dio_timer(void *ptr)
 
   if(instance->dio_send) {
     /* send DIO if counter is less than desired redundancy */
-    if(instance->dio_redundancy != 0 && instance->dio_counter < instance->dio_redundancy) {
+    if(instance->dio_redundancy == 0 || instance->dio_counter < instance->dio_redundancy) {
 #if RPL_CONF_STATS
       instance->dio_totsend++;
 #endif /* RPL_CONF_STATS */


### PR DESCRIPTION
This applies the same bug fix as contiki-os/contiki#1879 in order to correctly handle disabling DIO suppression.  Although ideally I guess this should wait until 6lbr is rebased onto Contiki again, anybody experimenting with disabling DIO suppression in a network with a 6lbr BR (for example to test contiki-os/contiki#1954) would find that no nodes could join the network.