### PR TITLE
6lbr on Sensortag

### DIFF
--- a/examples/6lbr/platform/srf06-cc26xx/Makefile.srf06-cc26xx
+++ b/examples/6lbr/platform/srf06-cc26xx/Makefile.srf06-cc26xx
@@ -18,10 +18,19 @@ SMALL=1
 #Currently only gpio is supported on CC26xx/CC13xx
 CC26XX_ENC28J60_ARCH?=gpio
 
+#Configure ENC28J60 Chip Select (CS) pin for Sensortag or Launchpad
+#For Lauchpad it is IOID_14, for Sensortag it is IOID_20
+ifeq ($(BOARD),sensortag/cc2650)
+CFLAGS += -DBOARD_SENSORTAG
+else
+CFLAGS += -DBOARD_LAUNCHPAD
+endif
+
 #Define the location of the NVM configuration : int, ext
 #int is the embedded code flash
 #ext is the external flash, only present on Sensortag and Launchpad
 CC26XX_NVM?=int
+
 
 CC26XX_FW?=bin
 

--- a/examples/6lbr/platform/srf06-cc26xx/Makefile.srf06-cc26xx
+++ b/examples/6lbr/platform/srf06-cc26xx/Makefile.srf06-cc26xx
@@ -31,7 +31,6 @@ endif
 #ext is the external flash, only present on Sensortag and Launchpad
 CC26XX_NVM?=int
 
-
 CC26XX_FW?=bin
 
 PROJECTDIRS += platform/srf06-cc26xx dev/enc28j60

--- a/examples/6lbr/platform/srf06-cc26xx/enc28j60-arch-gpio.c
+++ b/examples/6lbr/platform/srf06-cc26xx/enc28j60-arch-gpio.c
@@ -57,7 +57,11 @@
 
 #undef SPI_CS_PORT
 #ifndef CC26XX_ENC28J60_CONF_CS_PORT
+#ifdef BOARD_SENSORTAG
+#define SPI_CS_PORT   BOARD_IOID_DEVPACK_CS
+#else
 #define SPI_CS_PORT   IOID_14
+#endif
 #else
 #define SPI_CS_PORT   CC26XX_ENC28J60_CONF_CS_PORT
 #endif


### PR DESCRIPTION
I manage to run 6lbr on Sensortag (see issure #232). This changes add some config to compile 6lbr for Sensortag.
Ethernet module ENC28J60 is connected to SPI (shared with external memory) by default with IOID_20 for CS pin. 
To compile it run:
`make TARGET=srf06-cc26xx BOARD=sensortag/cc2650 CC26XX_NVM=ext`
Also my recent [contiki merge](https://github.com/contiki-os/contiki/pull/2168) should be in 6lbr in order this to work. 
