### PR TITLE
Slip-radio: add processing of slip commands for set RF channel and PAN ID.

### DIFF
--- a/examples/ipv6/slip-radio/no-framer.c
+++ b/examples/ipv6/slip-radio/no-framer.c
@@ -63,6 +63,21 @@ static const uint16_t mac_dst_pan_id = IEEE802154_PANID;
  */
 static const uint16_t mac_src_pan_id = IEEE802154_PANID;
 /*---------------------------------------------------------------------------*/
+/* Get current PAN ID */
+uint16_t
+no_framer_get_pan_id(void)
+{
+  return mac_src_pan_id;
+}
+/*---------------------------------------------------------------------------*/
+/* Set current PAN ID */
+void
+no_framer_set_pan_id(uint16_t pan_id)
+{
+  mac_dst_pan_id = pan_id;
+  mac_src_pan_id = pan_id;
+}
+/*---------------------------------------------------------------------------*/
 static int
 is_broadcast_addr(uint8_t mode, uint8_t *addr)
 {

--- a/examples/ipv6/slip-radio/no-framer.h
+++ b/examples/ipv6/slip-radio/no-framer.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2017, Swedish Institute of Computer Science.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Institute nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ */
+
+#ifndef NO_FRAMER_H_
+#define NO_FRAMER_H_
+
+/* Get current PAN ID */
+uint16_t no_framer_get_pan_id(void);
+
+/* Set current PAN ID */
+void no_framer_set_pan_id(uint16_t pan_id);
+
+#endif /* NO_FRAMER_H_ */

--- a/examples/ipv6/slip-radio/slip-radio.c
+++ b/examples/ipv6/slip-radio/slip-radio.c
@@ -48,6 +48,7 @@
 #include "cmd.h"
 #include "slip-radio.h"
 #include "packetutils.h"
+#include "no-framer.h"
 
 #ifdef SLIP_RADIO_CONF_SENSORS
 extern const struct slip_radio_sensors SLIP_RADIO_CONF_SENSORS;
@@ -154,19 +155,14 @@ slip_radio_cmd_handler(const uint8_t *data, int len)
     } else if(data[1] == 'P' && len == 4) {
       uint16_t pan_id = data[2] + (data[3] << 8);
       PRINTF("CMD: setting pan-id: %x\n", pan_id);
-      frame802154_set_pan_id(pan_id);
+      no_framer_set_pan_id(pan_id);
+      NETSTACK_RADIO.set_value(RADIO_PARAM_PAN_ID, pan_id);
       return 1;
     } else if(data[1] == 'C' && len == 3) {
-		uint8_t channel = data[2];
-		int rv = NETSTACK_RADIO.set_value(RADIO_PARAM_CHANNEL, channel);
-		if(rv == RADIO_RESULT_OK) {
-			uint8_t temp[3];
-			temp[0] = '!'; temp[1] = 'C';
-			temp[2] = channel;
-			cmd_send(temp, ARRAY_SIZE(temp));
-		}
-		return 1;
-	}
+      uint8_t channel = data[2];
+      NETSTACK_RADIO.set_value(RADIO_PARAM_CHANNEL, channel);
+      return 1;
+    }
   } else if(uip_buf[0] == '?') {
     PRINTF("Got request message of type %c\n", uip_buf[1]);
     if(data[1] == 'M' && len == 2) {
@@ -180,14 +176,14 @@ slip_radio_cmd_handler(const uint8_t *data, int len)
       cmd_send(uip_buf, uip_len);
       return 1;
     } else if(data[1] == 'P' && len == 2) {
-		uint16_t pan_id = frame802154_get_pan_id();
-		uip_buf[0] = '!'; uip_buf[1] = 'P';
-		uip_buf[2] = pan_id & 0xFF;
-		uip_buf[3] = (pan_id >> 8) & 0xFF;
-		uip_len = 4;
-		cmd_send(uip_buf, uip_len);
-		return 1;
-	}
+      uint16_t pan_id = no_framer_get_pan_id();
+      uip_buf[0] = '!'; uip_buf[1] = 'P';
+      uip_buf[2] = pan_id & 0xFF;
+      uip_buf[3] = (pan_id >> 8) & 0xFF;
+      uip_len = 4;
+      cmd_send(uip_buf, uip_len);
+      return 1;
+    }
   }
   return 0;
 }

--- a/examples/ipv6/slip-radio/slip-radio.c
+++ b/examples/ipv6/slip-radio/slip-radio.c
@@ -151,6 +151,11 @@ slip_radio_cmd_handler(const uint8_t *data, int len)
       watchdog_reboot();
 #endif
       return 1;
+    } else if(data[1] == 'P' && len == 4) {
+      uint16_t pan_id = data[2] + (data[3] << 8);
+      PRINTF("CMD: setting pan-id: %x\n", pan_id);
+      frame802154_set_pan_id(pan_id);
+      return 1;
     }
   } else if(uip_buf[0] == '?') {
     PRINTF("Got request message of type %c\n", uip_buf[1]);
@@ -164,7 +169,15 @@ slip_radio_cmd_handler(const uint8_t *data, int len)
       uip_len = 10;
       cmd_send(uip_buf, uip_len);
       return 1;
-    }
+    } else if(data[1] == 'P' && len == 2) {
+		uint16_t pan_id = frame802154_get_pan_id();
+		uip_buf[0] = '!'; uip_buf[1] = 'P';
+		uip_buf[2] = pan_id & 0xFF;
+		uip_buf[3] = (pan_id >> 8) & 0xFF;
+		uip_len = 4;
+		cmd_send(uip_buf, uip_len);
+		return 1;
+	}
   }
   return 0;
 }

--- a/examples/ipv6/slip-radio/slip-radio.c
+++ b/examples/ipv6/slip-radio/slip-radio.c
@@ -156,7 +156,17 @@ slip_radio_cmd_handler(const uint8_t *data, int len)
       PRINTF("CMD: setting pan-id: %x\n", pan_id);
       frame802154_set_pan_id(pan_id);
       return 1;
-    }
+    } else if(data[1] == 'C' && len == 3) {
+		uint8_t channel = data[2];
+		int rv = NETSTACK_RADIO.set_value(RADIO_PARAM_CHANNEL, channel);
+		if(rv == RADIO_RESULT_OK) {
+			uint8_t temp[3];
+			temp[0] = '!'; temp[1] = 'C';
+			temp[2] = channel;
+			cmd_send(temp, ARRAY_SIZE(temp));
+		}
+		return 1;
+	}
   } else if(uip_buf[0] == '?') {
     PRINTF("Got request message of type %c\n", uip_buf[1]);
     if(data[1] == 'M' && len == 2) {

--- a/examples/ipv6/slip-radio/slip-radio.h
+++ b/examples/ipv6/slip-radio/slip-radio.h
@@ -31,6 +31,10 @@
 #ifndef SLIP_RADIO_H_
 #define SLIP_RADIO_H_
 
+/*---------------------------------------------------------------------------*/
+#define ARRAY_SIZE(x) (sizeof(x) / sizeof(x[0]))
+
+/*---------------------------------------------------------------------------*/
 struct slip_radio_sensors {
   /** Initialize the driver */
   void (* init)(void);


### PR DESCRIPTION
6lbr send commands for set PAN ID and channel (see file examples/6lbr/platform/native/native-rdc.c), this patch implement in processing of this commands in examples/ipv6/slip-radio/.